### PR TITLE
Add ingress controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,40 @@
 
 [Azure Kubernetes Service (AKS)](https://azure.microsoft.com/en-gb/services/kubernetes-service/)
 Ingress Terraform Module.
+
+## Usage
+
+```hcl
+module "aks_ingress" {
+  source = "github.com/dbalcomb/terraform-azurerm-aks-ingress"
+
+  controller_name                = "aks-ingress"
+  controller_replicas            = 3
+  controller_ip_address          = "93.184.216.34"
+  controller_resource_group_name = "aks-network-rg"
+}
+```
+
+## Inputs
+
+| Name                           | Type   | Default      | Description                                        |
+| ------------------------------ | ------ | ------------ | -------------------------------------------------- |
+| controller_name                | string |              | The ingress controller resource name               |
+| controller_replicas            | number | 1            | The ingress controller replica count               |
+| controller_ip_address          | string |              | The ingress controller IP address                  |
+| controller_resource_group_name | string |              | The ingress controller network resource group name |
+| controller_image               | string | traefik:v1.7 | The ingress controller docker image name           |
+
+## Outputs
+
+| Name                           | Type   | Description                                        |
+| ------------------------------ | ------ | -------------------------------------------------- |
+| controller_name                | string | The ingress controller resource name               |
+| controller_replicas            | number | The ingress controller replica count               |
+| controller_ip_address          | string | The ingress controller IP address                  |
+| controller_resource_group_name | string | The ingress controller network resource group name |
+| controller_image               | string | The ingress controller docker image name           |
+
+## Modules
+
+- [Controller](modules/controller/README.md)

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,9 @@
-resource "kubernetes_namespace" "main" {
-  metadata {
-    name = var.name
-  }
+module "controller" {
+  source = "./modules/controller"
+
+  name                = var.controller_name
+  replicas            = var.controller_replicas
+  ip_address          = var.controller_ip_address
+  resource_group_name = var.controller_resource_group_name
+  image               = var.controller_image
 }

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -1,0 +1,50 @@
+# Controller
+
+This module configures an ingress controller for the Azure Kubernetes Service
+(AKS) cluster. The ingress controller is responsible for routing external
+traffic through the cluster to the appropriate backend service.
+
+## Usage
+
+```hcl
+module "controller" {
+  source = "github.com/dbalcomb/terraform-azurerm-aks-ingress//modules/controller"
+
+  name                = "aks-ingress"
+  replicas            = 3
+  ip_address          = "93.184.216.34"
+  resource_group_name = "aks-network-rg"
+}
+```
+
+## Inputs
+
+| Name                | Type   | Default      | Description                     |
+| ------------------- | ------ | ------------ | ------------------------------- |
+| name                | string |              | The resource name               |
+| replicas            | number | 1            | The replica count               |
+| ip_address          | string |              | The ingress IP address          |
+| resource_group_name | string |              | The network resource group name |
+| image               | string | traefik:v1.7 | The docker image name           |
+
+## Outputs
+
+| Name                | Type   | Description                     |
+| ------------------- | ------ | ------------------------------- |
+| name                | string | The resource name               |
+| replicas            | number | The replica count               |
+| ip_address          | string | The ingress IP address          |
+| resource_group_name | string | The network resource group name |
+| image               | string | The docker image name           |
+
+## Notes
+
+- The IP address must correspond to a Public IP resource in the given resource
+  group in order for the Azure Kubernetes Service to accept it.
+
+## References
+
+- [Traefik Documentation](https://docs.traefik.io/v1.7/)
+- [AKS Ingress Controller](https://docs.microsoft.com/en-gb/azure/aks/ingress-basic)
+- [AKS Ingress Controller With Static IP](https://docs.microsoft.com/en-gb/azure/aks/ingress-static-ip)
+- [AKS Load Balancer With Static IP](https://docs.microsoft.com/en-gb/azure/aks/static-ip)

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -1,0 +1,195 @@
+locals {
+  labels = {
+    "app.kubernetes.io/name"       = "ingress-controller"
+    "app.kubernetes.io/instance"   = substr(var.name, 0, 63)
+    "app.kubernetes.io/component"  = "controller"
+    "app.kubernetes.io/part-of"    = "ingress"
+    "app.kubernetes.io/managed-by" = "terraform"
+  }
+}
+
+resource "kubernetes_namespace" "main" {
+  metadata {
+    name   = var.name
+    labels = local.labels
+  }
+}
+
+resource "kubernetes_service_account" "main" {
+  metadata {
+    name      = var.name
+    namespace = kubernetes_namespace.main.metadata.0.name
+    labels    = local.labels
+  }
+}
+
+resource "kubernetes_service" "main" {
+  metadata {
+    name      = var.name
+    namespace = kubernetes_namespace.main.metadata.0.name
+    labels    = local.labels
+
+    annotations = {
+      "service.beta.kubernetes.io/azure-load-balancer-resource-group" = var.resource_group_name
+    }
+  }
+
+  spec {
+    type             = "LoadBalancer"
+    load_balancer_ip = var.ip_address
+    selector         = local.labels
+
+    port {
+      name        = "http"
+      port        = 80
+      protocol    = "TCP"
+      target_port = "http"
+    }
+
+    port {
+      name        = "https"
+      port        = 443
+      protocol    = "TCP"
+      target_port = "https"
+    }
+  }
+}
+
+locals {
+  config = file("${path.module}/templates/traefik.toml")
+}
+
+resource "kubernetes_config_map" "main" {
+  metadata {
+    name      = format("%s-config", var.name)
+    namespace = kubernetes_namespace.main.metadata.0.name
+    labels    = local.labels
+  }
+
+  data = {
+    "traefik.toml" = local.config
+  }
+}
+
+resource "kubernetes_deployment" "main" {
+  metadata {
+    name      = var.name
+    namespace = kubernetes_namespace.main.metadata.0.name
+    labels    = local.labels
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = local.labels
+    }
+
+    template {
+      metadata {
+        labels = local.labels
+      }
+
+      spec {
+        service_account_name            = kubernetes_service_account.main.metadata.0.name
+        automount_service_account_token = true
+
+        node_selector = {
+          "kubernetes.io/os" = "linux"
+        }
+
+        container {
+          name  = "ingress-controller"
+          image = var.image
+          args  = ["--configfile=/config/traefik.toml"]
+
+          port {
+            name           = "http"
+            protocol       = "TCP"
+            container_port = 80
+          }
+
+          port {
+            name           = "https"
+            protocol       = "TCP"
+            container_port = 443
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/config"
+            read_only  = true
+          }
+        }
+
+        volume {
+          name = "config"
+
+          config_map {
+            name = kubernetes_config_map.main.metadata.0.name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_pod_disruption_budget" "main" {
+  metadata {
+    name      = format("%s-pdb", var.name)
+    namespace = kubernetes_namespace.main.metadata.0.name
+    labels    = local.labels
+  }
+
+  spec {
+    min_available = 1
+
+    selector {
+      match_labels = local.labels
+    }
+  }
+}
+
+resource "kubernetes_cluster_role" "rbac" {
+  metadata {
+    name   = format("%s-rbac", var.name)
+    labels = local.labels
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["pods", "services", "endpoints", "secrets"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["extensions", "networking.k8s.io"]
+    resources  = ["ingresses"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  rule {
+    api_groups = ["extensions", "networking.k8s.io"]
+    resources  = ["ingresses/status"]
+    verbs      = ["update"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "rbac" {
+  metadata {
+    name   = format("%s-rbac", var.name)
+    labels = local.labels
+  }
+
+  role_ref {
+    name      = kubernetes_cluster_role.rbac.metadata.0.name
+    kind      = "ClusterRole"
+    api_group = "rbac.authorization.k8s.io"
+  }
+
+  subject {
+    name      = kubernetes_service_account.main.metadata.0.name
+    namespace = kubernetes_service_account.main.metadata.0.namespace
+    kind      = "ServiceAccount"
+  }
+}

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -1,0 +1,24 @@
+output "name" {
+  description = "The resource name"
+  value       = var.name
+}
+
+output "replicas" {
+  description = "The replica count"
+  value       = var.replicas
+}
+
+output "ip_address" {
+  description = "The ingress IP address"
+  value       = var.ip_address
+}
+
+output "resource_group_name" {
+  description = "The network resource group name"
+  value       = var.resource_group_name
+}
+
+output "image" {
+  description = "The docker image name"
+  value       = var.image
+}

--- a/modules/controller/templates/traefik.toml
+++ b/modules/controller/templates/traefik.toml
@@ -1,0 +1,11 @@
+defaultEntryPoints = ["http", "https"]
+
+[entryPoints]
+  [entryPoints.http]
+    address = ":80"
+
+  [entryPoints.https]
+    address = ":443"
+
+[kubernetes]
+  ingressClass = "traefik"

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  description = "The resource name"
+  type        = string
+}
+
+variable "replicas" {
+  description = "The replica count"
+  default     = 1
+  type        = number
+}
+
+variable "ip_address" {
+  description = "The ingress IP address"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The network resource group name"
+  type        = string
+}
+
+variable "image" {
+  description = "The docker image name"
+  default     = "traefik:v1.7"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,24 @@
-output "namespace" {
-  description = "The Kubernetes namespace"
-  value       = kubernetes_namespace.main
+output "controller_name" {
+  description = "The ingress controller resource name"
+  value       = module.controller.name
+}
+
+output "controller_replicas" {
+  description = "The ingress controller replica count"
+  value       = module.controller.replicas
+}
+
+output "controller_ip_address" {
+  description = "The ingress controller IP address"
+  value       = module.controller.ip_address
+}
+
+output "controller_resource_group_name" {
+  description = "The ingress controller network resource group name"
+  value       = module.controller.resource_group_name
+}
+
+output "controller_image" {
+  description = "The ingress controller docker image name"
+  value       = module.controller.image
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,26 @@
-variable "name" {
-  description = "The resource name"
+variable "controller_name" {
+  description = "The ingress controller resource name"
+  type        = string
+}
+
+variable "controller_replicas" {
+  description = "The ingress controller replica count"
+  default     = 1
+  type        = number
+}
+
+variable "controller_ip_address" {
+  description = "The ingress controller IP address"
+  type        = string
+}
+
+variable "controller_resource_group_name" {
+  description = "The ingress controller network resource group name"
+  type        = string
+}
+
+variable "controller_image" {
+  description = "The ingress controller docker image name"
+  default     = "traefik:v1.7"
   type        = string
 }


### PR DESCRIPTION
This adds a submodule that provides an ingress controller using the `traefik` docker image. This differs to the official Azure documentation that instead refers to using `nginx-ingress`.