### PR TITLE
Add ingress controller health probes

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -115,6 +115,40 @@ resource "kubernetes_deployment" "main" {
             container_port = 443
           }
 
+          port {
+            name           = "ping"
+            protocol       = "TCP"
+            container_port = 8082
+          }
+
+          readiness_probe {
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 2
+            success_threshold     = 1
+            failure_threshold     = 1
+
+            http_get {
+              path   = "/ping"
+              port   = "ping"
+              scheme = "HTTP"
+            }
+          }
+
+          liveness_probe {
+            initial_delay_seconds = 10
+            period_seconds        = 10
+            timeout_seconds       = 2
+            success_threshold     = 1
+            failure_threshold     = 3
+
+            http_get {
+              path   = "/ping"
+              port   = "ping"
+              scheme = "HTTP"
+            }
+          }
+
           volume_mount {
             name       = "config"
             mount_path = "/config"

--- a/modules/controller/templates/traefik.toml
+++ b/modules/controller/templates/traefik.toml
@@ -7,5 +7,11 @@ defaultEntryPoints = ["http", "https"]
   [entryPoints.https]
     address = ":443"
 
+  [entryPoints.ping]
+    address = ":8082"
+
+[ping]
+  entryPoint = "ping"
+
 [kubernetes]
   ingressClass = "traefik"


### PR DESCRIPTION
This adds readiness and liveness health probes for the ingress controller deployment.