### PR TITLE
Add ingress controller prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ module "aks_ingress" {
 | controller_ip_address          | string |              | The ingress controller IP address                  |
 | controller_resource_group_name | string |              | The ingress controller network resource group name |
 | controller_image               | string | traefik:v1.7 | The ingress controller docker image name           |
+| controller_metrics             | bool   | false        | Enable ingress controller prometheus metrics       |
 
 ## Outputs
 
@@ -35,6 +36,7 @@ module "aks_ingress" {
 | controller_ip_address          | string | The ingress controller IP address                  |
 | controller_resource_group_name | string | The ingress controller network resource group name |
 | controller_image               | string | The ingress controller docker image name           |
+| controller_metrics             | bool   | Enable ingress controller prometheus metrics       |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -6,4 +6,5 @@ module "controller" {
   ip_address          = var.controller_ip_address
   resource_group_name = var.controller_resource_group_name
   image               = var.controller_image
+  metrics             = var.controller_metrics
 }

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -26,6 +26,7 @@ module "controller" {
 | ip_address          | string |              | The ingress IP address          |
 | resource_group_name | string |              | The network resource group name |
 | image               | string | traefik:v1.7 | The docker image name           |
+| metrics             | bool   | false        | Enable prometheus metrics       |
 
 ## Outputs
 
@@ -36,6 +37,7 @@ module "controller" {
 | ip_address          | string | The ingress IP address          |
 | resource_group_name | string | The network resource group name |
 | image               | string | The docker image name           |
+| metrics             | bool   | Enable prometheus metrics       |
 
 ## Notes
 

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -22,3 +22,8 @@ output "image" {
   description = "The docker image name"
   value       = var.image
 }
+
+output "metrics" {
+  description = "Enable prometheus metrics"
+  value       = var.metrics
+}

--- a/modules/controller/templates/traefik.toml
+++ b/modules/controller/templates/traefik.toml
@@ -10,8 +10,19 @@ defaultEntryPoints = ["http", "https"]
   [entryPoints.ping]
     address = ":8082"
 
+  %{ if metrics }
+  [entryPoints.metrics]
+    address = ":9100"
+  %{ endif }
+
 [ping]
   entryPoint = "ping"
 
 [kubernetes]
   ingressClass = "traefik"
+
+%{ if metrics }
+[metrics]
+  [metrics.prometheus]
+    entryPoint = "metrics"
+%{ endif }

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -24,3 +24,9 @@ variable "image" {
   default     = "traefik:v1.7"
   type        = string
 }
+
+variable "metrics" {
+  description = "Enable prometheus metrics"
+  default     = false
+  type        = bool
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -22,3 +22,8 @@ output "controller_image" {
   description = "The ingress controller docker image name"
   value       = module.controller.image
 }
+
+output "controller_metrics" {
+  description = "Enable ingress controller prometheus metrics"
+  value       = module.controller.metrics
+}

--- a/variables.tf
+++ b/variables.tf
@@ -24,3 +24,9 @@ variable "controller_image" {
   default     = "traefik:v1.7"
   type        = string
 }
+
+variable "controller_metrics" {
+  description = "Enable ingress controller prometheus metrics"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
This adds the ability to enable prometheus metrics collection for the ingress controller.