### PR TITLE
Add config checksum annotation

### DIFF
--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -92,6 +92,7 @@ resource "kubernetes_deployment" "main" {
         labels = local.labels
 
         annotations = {
+          "checksum/config"      = sha256(local.config)
           "prometheus.io/scrape" = var.metrics ? "true" : "false"
           "prometheus.io/path"   = var.metrics ? "/metrics" : null
           "prometheus.io/port"   = var.metrics ? "9100" : null


### PR DESCRIPTION
This adds a `checksum/config` annotation to the ingress controller pods to ensure that configuration changes trigger the replacement of pods. This could alternatively be done at the deployment level.