### PR TITLE
Add ip address module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,34 +9,37 @@ Ingress Terraform Module.
 module "aks_ingress" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-ingress"
 
-  controller_name                = "aks-ingress"
-  controller_replicas            = 3
-  controller_ip_address          = "93.184.216.34"
-  controller_resource_group_name = "aks-network-rg"
+  ip_address_name   = "aks-ingress"
+  ip_address_region = "uksouth"
+
+  controller_name     = "aks-ingress"
+  controller_replicas = 3
 }
 ```
 
 ## Inputs
 
-| Name                           | Type   | Default      | Description                                        |
-| ------------------------------ | ------ | ------------ | -------------------------------------------------- |
-| controller_name                | string |              | The ingress controller resource name               |
-| controller_replicas            | number | 1            | The ingress controller replica count               |
-| controller_ip_address          | string |              | The ingress controller IP address                  |
-| controller_resource_group_name | string |              | The ingress controller network resource group name |
-| controller_image               | string | traefik:v1.7 | The ingress controller docker image name           |
-| controller_metrics             | bool   | false        | Enable ingress controller prometheus metrics       |
+| Name                | Type   | Default      | Description                                  |
+| ------------------- | ------ | ------------ | -------------------------------------------- |
+| controller_name     | string |              | The ingress controller resource name         |
+| controller_replicas | number | 1            | The ingress controller replica count         |
+| controller_image    | string | traefik:v1.7 | The ingress controller docker image name     |
+| controller_metrics  | bool   | false        | Enable ingress controller prometheus metrics |
+| ip_address_name     | string |              | The IP address resource name                 |
+| ip_address_region   | string |              | The IP address resource location             |
 
 ## Outputs
 
-| Name                           | Type   | Description                                        |
-| ------------------------------ | ------ | -------------------------------------------------- |
-| controller_name                | string | The ingress controller resource name               |
-| controller_replicas            | number | The ingress controller replica count               |
-| controller_ip_address          | string | The ingress controller IP address                  |
-| controller_resource_group_name | string | The ingress controller network resource group name |
-| controller_image               | string | The ingress controller docker image name           |
-| controller_metrics             | bool   | Enable ingress controller prometheus metrics       |
+| Name                           | Type   | Description                                  |
+| ------------------------------ | ------ | -------------------------------------------- |
+| controller_name                | string | The ingress controller resource name         |
+| controller_replicas            | number | The ingress controller replica count         |
+| controller_image               | string | The ingress controller docker image name     |
+| controller_metrics             | bool   | Enable ingress controller prometheus metrics |
+| ip_address_name                | string | The IP address resource name                 |
+| ip_address_region              | string | The IP address resource location             |
+| ip_address_ip_address          | string | The IP address value                         |
+| ip_address_resource_group_name | string | The IP address resource group name           |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,17 @@
+module "ip_address" {
+  source = "./modules/ip-address"
+
+  name   = var.ip_address_name
+  region = var.ip_address_region
+}
+
 module "controller" {
   source = "./modules/controller"
 
   name                = var.controller_name
   replicas            = var.controller_replicas
-  ip_address          = var.controller_ip_address
-  resource_group_name = var.controller_resource_group_name
+  ip_address          = module.ip_address.ip_address
+  resource_group_name = module.ip_address.resource_group_name
   image               = var.controller_image
   metrics             = var.controller_metrics
 }

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -43,6 +43,8 @@ module "controller" {
 
 - The IP address must correspond to a Public IP resource in the given resource
   group in order for the Azure Kubernetes Service to accept it.
+- The IP address must be unique to this ingress controller as Kubernetes does
+  not currently allow IP addresses to be shared across services.
 
 ## References
 

--- a/modules/ip-address/README.md
+++ b/modules/ip-address/README.md
@@ -1,0 +1,32 @@
+# IP Address
+
+This module configures the ingress IP address for the Azure Kubernetes Service
+(AKS) cluster. This configuration can then be sent to the ingress controller to
+handle load balancing and routing.
+
+## Usage
+
+```hcl
+module "ip_address" {
+  source = "github.com/dbalcomb/terraform-azurerm-aks-ingress//modules/ip-address"
+
+  name   = "aks-ingress"
+  region = "uksouth"
+}
+```
+
+## Inputs
+
+| Name   | Type   | Default | Description           |
+| ------ | ------ | ------- | --------------------- |
+| name   | string |         | The resource name     |
+| region | string |         | The resource location |
+
+## Outputs
+
+| Name                | Type   | Description             |
+| ------------------- | ------ | ----------------------- |
+| name                | string | The resource name       |
+| region              | string | The resource location   |
+| ip_address          | string | The ingress IP address  |
+| resource_group_name | string | The resource group name |

--- a/modules/ip-address/main.tf
+++ b/modules/ip-address/main.tf
@@ -1,0 +1,20 @@
+resource "azurerm_resource_group" "main" {
+  name     = format("%s-rg", var.name)
+  location = var.region
+
+  tags = {
+    provisioner = "terraform"
+  }
+}
+
+resource "azurerm_public_ip" "main" {
+  name                = format("%s-ip", var.name)
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "Standard"
+  allocation_method   = "Static"
+
+  tags = {
+    provisioner = "terraform"
+  }
+}

--- a/modules/ip-address/outputs.tf
+++ b/modules/ip-address/outputs.tf
@@ -1,0 +1,19 @@
+output "name" {
+  description = "The resource name"
+  value       = var.name
+}
+
+output "region" {
+  description = "The resource location"
+  value       = var.region
+}
+
+output "ip_address" {
+  description = "The ingress IP address"
+  value       = azurerm_public_ip.main.ip_address
+}
+
+output "resource_group_name" {
+  description = "The resource group name"
+  value       = azurerm_resource_group.main.name
+}

--- a/modules/ip-address/variables.tf
+++ b/modules/ip-address/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "The resource name"
+  type        = string
+}
+
+variable "region" {
+  description = "The resource location"
+  type        = string
+}

--- a/modules/ip-address/versions.tf
+++ b/modules/ip-address/versions.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    azurerm = ">= 1.42, < 2.0"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,16 +8,6 @@ output "controller_replicas" {
   value       = module.controller.replicas
 }
 
-output "controller_ip_address" {
-  description = "The ingress controller IP address"
-  value       = module.controller.ip_address
-}
-
-output "controller_resource_group_name" {
-  description = "The ingress controller network resource group name"
-  value       = module.controller.resource_group_name
-}
-
 output "controller_image" {
   description = "The ingress controller docker image name"
   value       = module.controller.image
@@ -26,4 +16,24 @@ output "controller_image" {
 output "controller_metrics" {
   description = "Enable ingress controller prometheus metrics"
   value       = module.controller.metrics
+}
+
+output "ip_address_name" {
+  description = "The IP address resource name"
+  value       = module.controller.ip_address
+}
+
+output "ip_address_region" {
+  description = "The IP address resource location"
+  value       = module.controller.resource_group_name
+}
+
+output "ip_address_ip_address" {
+  description = "The IP address value"
+  value       = module.ip_address.ip_address
+}
+
+output "ip_address_resource_group_name" {
+  description = "The IP address resource group name"
+  value       = module.ip_address.resource_group_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,16 +9,6 @@ variable "controller_replicas" {
   type        = number
 }
 
-variable "controller_ip_address" {
-  description = "The ingress controller IP address"
-  type        = string
-}
-
-variable "controller_resource_group_name" {
-  description = "The ingress controller network resource group name"
-  type        = string
-}
-
 variable "controller_image" {
   description = "The ingress controller docker image name"
   default     = "traefik:v1.7"
@@ -29,4 +19,14 @@ variable "controller_metrics" {
   description = "Enable ingress controller prometheus metrics"
   default     = false
   type        = bool
+}
+
+variable "ip_address_name" {
+  description = "The IP address resource name"
+  type        = string
+}
+
+variable "ip_address_region" {
+  description = "The IP address resource location"
+  type        = string
 }


### PR DESCRIPTION
This adds a submodule to handle the creation of public IP address resources. The reason for inclusion is due to a unique IP address being required per ingress controller service. This rules out re-using the egress IP address provided by the cluster.