### PR TITLE
Add missing module documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ module "aks_ingress" {
 ## Modules
 
 - [Controller](modules/controller/README.md)
+- [IP Address](modules/ip-address/README.md)


### PR DESCRIPTION
This adds the missing documentation link for the `ip-address` module.