### PR TITLE
Add cert-manager prometheus metrics

### DIFF
--- a/modules/cert-manager/README.md
+++ b/modules/cert-manager/README.md
@@ -10,21 +10,24 @@ via HTTPS.
 module "cert_manager" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-ingress//modules/cert-manager"
 
-  name = "aks-cert-manager"
+  name    = "aks-cert-manager"
+  metrics = true
 }
 ```
 
 ## Inputs
 
-| Name   | Type     | Default        | Description        |
-| ------ | -------- | -------------- | ------------------ |
-| `name` | `string` | `cert-manager` | The resource name  |
+| Name      | Type     | Default        | Description               |
+| --------- | -------- | -------------- | ------------------------- |
+| `name`    | `string` | `cert-manager` | The resource name         |
+| `metrics` | `bool`   | `false`        | Enable prometheus metrics |
 
 ## Outputs
 
-| Name   | Type     | Description        |
-| ------ | -------- | ------------------ |
-| `name` | `string` | The resource name  |
+| Name      | Type     | Description               |
+| --------- | -------- | ------------------------- |
+| `name`    | `string` | The resource name         |
+| `metrics` | `bool`   | Enable prometheus metrics |
 
 ## Notes
 

--- a/modules/cert-manager/main.tf
+++ b/modules/cert-manager/main.tf
@@ -32,12 +32,30 @@ resource "null_resource" "definitions" {
   ]
 }
 
+locals {
+  metrics = {
+    "prometheus.enabled"                    = "true"
+    "podAnnotations.prometheus\\.io/scrape" = "true"
+    "podAnnotations.prometheus\\.io/path"   = "/metrics"
+    "podAnnotations.prometheus\\.io/port"   = "9402"
+  }
+}
+
 resource "helm_release" "main" {
   name       = var.name
   namespace  = kubernetes_namespace.main.metadata.0.name
   repository = data.helm_repository.main.metadata.0.name
   chart      = "cert-manager"
   version    = "0.13"
+
+  dynamic "set" {
+    for_each = var.metrics ? local.metrics : {}
+
+    content {
+      name  = set.key
+      value = set.value
+    }
+  }
 
   depends_on = [
     null_resource.definitions,

--- a/modules/cert-manager/outputs.tf
+++ b/modules/cert-manager/outputs.tf
@@ -2,3 +2,8 @@ output "name" {
   description = "The resource name"
   value       = helm_release.main.metadata.0.name
 }
+
+output "metrics" {
+  description = "Enable prometheus metrics"
+  value       = var.metrics
+}

--- a/modules/cert-manager/variables.tf
+++ b/modules/cert-manager/variables.tf
@@ -3,3 +3,9 @@ variable "name" {
   default     = "cert-manager"
   type        = string
 }
+
+variable "metrics" {
+  description = "Enable prometheus metrics"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
This adds the ability to enable prometheus metrics collection for the `cert-manager` utility.