### PR TITLE
Fix invalid controller configuration ingress class

### DIFF
--- a/modules/controller/templates/traefik.toml
+++ b/modules/controller/templates/traefik.toml
@@ -19,7 +19,7 @@ defaultEntryPoints = ["http", "https"]
   entryPoint = "ping"
 
 [kubernetes]
-  ingressClass = ${ class }
+  ingressClass = "${ class }"
 
 %{ if metrics }
 [metrics]


### PR DESCRIPTION
This fixes the controller config file by enclosing the ingress class with quotes. The following is the logged error message:

```
Error reading TOML config file /config/traefik.toml : Near line 19 (last key parsed 'kubernetes.ingressClass'): expected value but found "traefik" instead
```