### PR TITLE
Add ingress route tls support

### DIFF
--- a/modules/route/README.md
+++ b/modules/route/README.md
@@ -24,6 +24,12 @@ module "host" {
   # ...
 }
 
+module "issuer" {
+  source = "github.com/dbalcomb/terraform-azurerm-aks-cert-manager//modules/issuer"
+
+  # ...
+}
+
 module "route" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-ingress//modules/route"
 
@@ -32,6 +38,7 @@ module "route" {
   host    = module.host
   backend = module.backend
   ingress = module.ingress
+  issuer  = module.issuer
 }
 ```
 
@@ -49,6 +56,8 @@ module "route" {
 | `backend.port`      | `number` |         | The backend port          |
 | `ingress`           | `object` |         | The ingress configuration |
 | `ingress.class`     | `string` |         | The ingress class         |
+| `issuer`            | `object` | `null`  | The issuer configuration  |
+| `issuer.name`       | `string` |         | The issuer name           |
 
 ## Outputs
 
@@ -59,3 +68,4 @@ module "route" {
 | `host`    | `object` | The host configuration    |
 | `backend` | `object` | The backend configuration |
 | `ingress` | `object` | The ingress configuration |
+| `issuer`  | `object` | The issuer configuration  |

--- a/modules/route/outputs.tf
+++ b/modules/route/outputs.tf
@@ -22,3 +22,8 @@ output "ingress" {
   description = "The ingress configuration"
   value       = var.ingress
 }
+
+output "issuer" {
+  description = "The issuer configuration"
+  value       = var.issuer
+}

--- a/modules/route/variables.tf
+++ b/modules/route/variables.tf
@@ -31,3 +31,11 @@ variable "ingress" {
     class = string
   })
 }
+
+variable "issuer" {
+  description = "The issuer configuration"
+  default     = null
+  type = object({
+    name = string
+  })
+}


### PR DESCRIPTION
This adds support for enabling TLS for the ingress route when passing in certificate issuer configuration.