### PR TITLE
Fix minimum terraform version for route module

### DIFF
--- a/modules/route/versions.tf
+++ b/modules/route/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.20"
 
   required_providers {
     kubernetes = ">= 1.10"


### PR DESCRIPTION
This updates the minimum terraform version required by the route module due to the use of new functions introduced in 0.12.20.