### PR TITLE
Fix disabled tls on https entrypoint

### DIFF
--- a/modules/controller/templates/traefik.toml
+++ b/modules/controller/templates/traefik.toml
@@ -7,6 +7,8 @@ defaultEntryPoints = ["http", "https"]
   [entryPoints.https]
     address = ":443"
 
+    [entryPoints.https.tls]
+
   [entryPoints.ping]
     address = ":8082"
 


### PR DESCRIPTION
This fixes the disabled TLS support on the HTTPS entrypoint.