### PR TITLE
Move controller namespace to root module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+resource "kubernetes_namespace" "main" {
+  metadata {
+    name = var.controller_name
+  }
+}
+
 module "ip_address" {
   source = "./modules/ip-address"
 
@@ -10,6 +16,7 @@ module "controller" {
   source = "./modules/controller"
 
   name                = var.controller_name
+  namespace           = kubernetes_namespace.main.metadata.0.name
   replicas            = var.controller_replicas
   ip_address          = module.ip_address.ip_address
   resource_group_name = module.ip_address.resource_group_name

--- a/modules/controller/README.md
+++ b/modules/controller/README.md
@@ -22,6 +22,7 @@ module "controller" {
 | Name                  | Type     | Default        | Description                     |
 | --------------------- | -------- | -------------- | ------------------------------- |
 | `name`                | `string` |                | The resource name               |
+| `namespace`           | `string` |                | The resource namespace          |
 | `replicas`            | `number` | `1`            | The replica count               |
 | `ip_address`          | `string` |                | The ingress IP address          |
 | `resource_group_name` | `string` |                | The network resource group name |
@@ -34,6 +35,7 @@ module "controller" {
 | Name                  | Type     | Description                     |
 | --------------------- | -------- | ------------------------------- |
 | `name`                | `string` | The resource name               |
+| `namespace`           | `string` | The resource namespace          |
 | `replicas`            | `number` | The replica count               |
 | `ip_address`          | `string` | The ingress IP address          |
 | `resource_group_name` | `string` | The network resource group name |

--- a/modules/controller/main.tf
+++ b/modules/controller/main.tf
@@ -8,17 +8,10 @@ locals {
   }
 }
 
-resource "kubernetes_namespace" "main" {
-  metadata {
-    name   = var.name
-    labels = local.labels
-  }
-}
-
 resource "kubernetes_service_account" "main" {
   metadata {
     name      = var.name
-    namespace = kubernetes_namespace.main.metadata.0.name
+    namespace = var.namespace
     labels    = local.labels
   }
 }
@@ -26,7 +19,7 @@ resource "kubernetes_service_account" "main" {
 resource "kubernetes_service" "main" {
   metadata {
     name      = var.name
-    namespace = kubernetes_namespace.main.metadata.0.name
+    namespace = var.namespace
     labels    = local.labels
 
     annotations = {
@@ -65,7 +58,7 @@ locals {
 resource "kubernetes_config_map" "main" {
   metadata {
     name      = format("%s-config", var.name)
-    namespace = kubernetes_namespace.main.metadata.0.name
+    namespace = var.namespace
     labels    = local.labels
   }
 
@@ -77,7 +70,7 @@ resource "kubernetes_config_map" "main" {
 resource "kubernetes_deployment" "main" {
   metadata {
     name      = var.name
-    namespace = kubernetes_namespace.main.metadata.0.name
+    namespace = var.namespace
     labels    = local.labels
   }
 
@@ -191,7 +184,7 @@ resource "kubernetes_deployment" "main" {
 resource "kubernetes_pod_disruption_budget" "main" {
   metadata {
     name      = format("%s-pdb", var.name)
-    namespace = kubernetes_namespace.main.metadata.0.name
+    namespace = var.namespace
     labels    = local.labels
   }
 

--- a/modules/controller/outputs.tf
+++ b/modules/controller/outputs.tf
@@ -3,6 +3,11 @@ output "name" {
   value       = var.name
 }
 
+output "namespace" {
+  description = "The resource namespace"
+  value       = var.namespace
+}
+
 output "replicas" {
   description = "The replica count"
   value       = var.replicas

--- a/modules/controller/variables.tf
+++ b/modules/controller/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   type        = string
 }
 
+variable "namespace" {
+  description = "The resource namespace"
+  type        = string
+}
+
 variable "replicas" {
   description = "The replica count"
   default     = 1

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = ">= 0.12"
+
+  required_providers {
+    kubernetes = ">= 1.10"
+  }
+}


### PR DESCRIPTION
This repurposes the controller namespace to be a generic ingress namespace to support future resource additions.