### PR TITLE
Move ip address resource group to root module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,18 @@
+resource "azurerm_resource_group" "main" {
+  name     = format("%s-rg", var.ip_address_name)
+  location = var.ip_address_region
+
+  tags = {
+    provisioner = "terraform"
+  }
+}
+
+resource "azurerm_role_assignment" "main" {
+  principal_id         = var.cluster_service_principal_id
+  scope                = azurerm_resource_group.main.id
+  role_definition_name = "Network Contributor"
+}
+
 resource "kubernetes_namespace" "main" {
   metadata {
     name = var.controller_name
@@ -7,9 +22,9 @@ resource "kubernetes_namespace" "main" {
 module "ip_address" {
   source = "./modules/ip-address"
 
-  name                 = var.ip_address_name
-  region               = var.ip_address_region
-  service_principal_id = var.cluster_service_principal_id
+  name   = var.ip_address_name
+  group  = azurerm_resource_group.main.name
+  region = var.ip_address_region
 }
 
 module "controller" {
@@ -19,7 +34,7 @@ module "controller" {
   namespace           = kubernetes_namespace.main.metadata.0.name
   replicas            = var.controller_replicas
   ip_address          = module.ip_address.ip_address
-  resource_group_name = module.ip_address.resource_group_name
+  resource_group_name = azurerm_resource_group.main.name
   image               = var.controller_image
   class               = var.class
   metrics             = var.controller_metrics

--- a/modules/ip-address/README.md
+++ b/modules/ip-address/README.md
@@ -10,26 +10,25 @@ handle load balancing and routing.
 module "ip_address" {
   source = "github.com/dbalcomb/terraform-azurerm-aks-ingress//modules/ip-address"
 
-  name                 = "aks-ingress"
-  region               = "uksouth"
-  service_principal_id = "00000000-0000-0000-0000-000000000000"
+  name   = "aks-ingress"
+  group  = "aks-ingress-rg"
+  region = "uksouth"
 }
 ```
 
 ## Inputs
 
-| Name                   | Type     | Default | Description                      |
-| ---------------------- | -------- | ------- | -------------------------------- |
-| `name`                 | `string` |         | The resource name                |
-| `region`               | `string` |         | The resource location            |
-| `service_principal_id` | `string` |         | The cluster service principal ID |
+| Name     | Type     | Default | Description           |
+| -------- | -------- | ------- | --------------------- |
+| `name`   | `string` |         | The resource name     |
+| `group`  | `string` |         | The resource group    |
+| `region` | `string` |         | The resource location |
 
 ## Outputs
 
-| Name                   | Type     | Description                      |
-| ---------------------- | -------- | -------------------------------- |
-| `name`                 | `string` | The resource name                |
-| `region`               | `string` | The resource location            |
-| `service_principal_id` | `string` | The cluster service principal ID |
-| `ip_address`           | `string` | The ingress IP address           |
-| `resource_group_name`  | `string` | The resource group name          |
+| Name         | Type     | Description            |
+| ------------ | -------- | ---------------------- |
+| `name`       | `string` | The resource name      |
+| `group`      | `string` | The resource group     |
+| `region`     | `string` | The resource location  |
+| `ip_address` | `string` | The ingress IP address |

--- a/modules/ip-address/main.tf
+++ b/modules/ip-address/main.tf
@@ -1,26 +1,11 @@
-resource "azurerm_resource_group" "main" {
-  name     = format("%s-rg", var.name)
-  location = var.region
-
-  tags = {
-    provisioner = "terraform"
-  }
-}
-
 resource "azurerm_public_ip" "main" {
   name                = format("%s-ip", var.name)
-  location            = azurerm_resource_group.main.location
-  resource_group_name = azurerm_resource_group.main.name
+  resource_group_name = var.group
+  location            = var.region
   sku                 = "Standard"
   allocation_method   = "Static"
 
   tags = {
     provisioner = "terraform"
   }
-}
-
-resource "azurerm_role_assignment" "main" {
-  principal_id         = var.service_principal_id
-  scope                = azurerm_resource_group.main.id
-  role_definition_name = "Network Contributor"
 }

--- a/modules/ip-address/outputs.tf
+++ b/modules/ip-address/outputs.tf
@@ -3,22 +3,17 @@ output "name" {
   value       = var.name
 }
 
+output "group" {
+  description = "The resource group"
+  value       = var.group
+}
+
 output "region" {
   description = "The resource location"
   value       = var.region
 }
 
-output "service_principal_id" {
-  description = "The cluster service principal ID"
-  value       = var.service_principal_id
-}
-
 output "ip_address" {
   description = "The ingress IP address"
   value       = azurerm_public_ip.main.ip_address
-}
-
-output "resource_group_name" {
-  description = "The resource group name"
-  value       = azurerm_resource_group.main.name
 }

--- a/modules/ip-address/variables.tf
+++ b/modules/ip-address/variables.tf
@@ -3,12 +3,12 @@ variable "name" {
   type        = string
 }
 
-variable "region" {
-  description = "The resource location"
+variable "group" {
+  description = "The resource group"
   type        = string
 }
 
-variable "service_principal_id" {
-  description = "The cluster service principal ID"
+variable "region" {
+  description = "The resource location"
   type        = string
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -35,7 +35,7 @@ output "ip_address_ip_address" {
 
 output "ip_address_resource_group_name" {
   description = "The IP address resource group name"
-  value       = module.ip_address.resource_group_name
+  value       = module.ip_address.group
 }
 
 output "cluster_service_principal_id" {

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
+    azurerm    = ">= 1.42, < 2.0"
     kubernetes = ">= 1.10"
   }
 }


### PR DESCRIPTION
This moves the resource group used by the IP address module to the root module to allow future resources to share the same group.