### PR TITLE
Add backend volume support

### DIFF
--- a/modules/backend/README.md
+++ b/modules/backend/README.md
@@ -14,24 +14,108 @@ module "backend" {
   namespace = "aks-backend"
   image     = "nginx:latest"
   replicas  = 3
+
+  volumes = {
+    one = {
+      name = "one"
+      type = "config"
+      path = "/azure/config"
+
+      config = {
+        name = "aks-backend-config"
+        mode = "0777"
+
+        items = [
+          {
+            name = "one.yml"
+            mode = "0644"
+            path = "path/to/one.yml"
+          },
+          {
+            name = "two.yml"
+            mode = "0700"
+            path = "path/to/two.yml"
+          }
+        ]
+      }
+    }
+
+    two = {
+      name = "two"
+      type = "secret"
+      path = "/azure/secret"
+
+      secret = {
+        name = "aks-backend-secret"
+        mode = "0777"
+      }
+    }
+
+    three = {
+      name      = "three"
+      type      = "share"
+      path      = "/azure/share"
+      directory = "production"
+      read_only = true
+
+      share = {
+        name = "myshare"
+
+        account = {
+          name = "myaccount"
+          keys = ["key"]
+        }
+      }
+    }
+  }
 }
 ```
 
 ## Inputs
 
-| Name        | Type     | Default   | Description                                         |
-| ----------- | -------- | --------- | --------------------------------------------------- |
-| `name`      | `string` |           | The backend name                                    |
-| `namespace` | `string` | `null`    | The backend namespace or `null` to create a new one |
-| `image`     | `string` |           | The docker image name                               |
-| `replicas`  | `number` | `1`       | The replica count                                   |
+| Name                             | Type     | Default    | Description                                         |
+| -------------------------------- | -------- | ---------- | --------------------------------------------------- |
+| `name`                           | `string` |            | The backend name                                    |
+| `namespace`                      | `string` | `null`     | The backend namespace or `null` to create a new one |
+| `image`                          | `string` |            | The docker image name                               |
+| `replicas`                       | `number` | `1`        | The replica count                                   |
+| `volumes`                        | `object` |            | The volume configuration                            |
+| `volumes.*`                      | `object` |            | The volume instance configuration                   |
+| `volumes.*.type`                 | `string` |            | The volume type (`config`, `secret` or `share`)     |
+| `volumes.*.name`                 | `string` | *computed* | The volume name (defaults to volume key)            |
+| `volumes.*.path`                 | `string` |            | The volume mount path                               |
+| `volumes.*.directory`            | `string` | `""`       | The volume source path                              |
+| `volumes.*.read_only`            | `bool`   | `false`    | Enable read-only access to volume                   |
+| `volumes.*.config`               | `object` | `null`     | The `config` volume type configuration              |
+| `volumes.*.config.name`          | `string` |            | The Kubernetes config name                          |
+| `volumes.*.config.mode`          | `string` | `0644`     | The Kubernetes config permissions mode default      |
+| `volumes.*.config.items`         | `list`   | *all*      | The Kubernetes config file list                     |
+| `volumes.*.config.items.*`       | `object` |            | The Kubernetes config file configuration            |
+| `volumes.*.config.items.*.name`  | `string` |            | The Kubernetes config file name                     |
+| `volumes.*.config.items.*.mode`  | `string` | `null`     | The Kubernetes config file permissions mode         |
+| `volumes.*.config.items.*.path`  | `string` |            | The Kubernetes config file mount path               |
+| `volumes.*.secret`               | `object` | `null`     | The `secret` volume type configuration              |
+| `volumes.*.secret.name`          | `string` |            | The Kubernetes secret name                          |
+| `volumes.*.secret.mode`          | `string` | `0644`     | The Kubernetes secret permissions mode default      |
+| `volumes.*.secret.items`         | `list`   | *all*      | The Kubernetes secret file list                     |
+| `volumes.*.secret.items.*`       | `object` |            | The Kubernetes secret file configuration            |
+| `volumes.*.secret.items.*.name`  | `string` |            | The Kubernetes secret file name                     |
+| `volumes.*.secret.items.*.mode`  | `string` | `null`     | The Kubernetes secret file permissions mode         |
+| `volumes.*.secret.items.*.path`  | `string` |            | The Kubernetes secret file mount path               |
+| `volumes.*.share`                | `object` | `null`     | The `share` volume type configuration               |
+| `volumes.*.share.name`           | `string` |            | The Azure file share name                           |
+| `volumes.*.share.account`        | `object` |            | The Azure storage account configuration             |
+| `volumes.*.share.account.name`   | `string` |            | The Azure storage account name                      |
+| `volumes.*.share.account.keys`   | `list`   |            | The Azure storage account access keys               |
+| `volumes.*.share.account.keys.*` | `string` |            | The Azure storage account access key                |
 
 ## Outputs
 
-| Name        | Type     | Description           |
-| ----------- | -------- | --------------------- |
-| `name`      | `string` | The backend name      |
-| `namespace` | `string` | The backend namespace |
-| `port`      | `number` | The backend port      |
-| `image`     | `string` | The docker image name |
-| `replicas`  | `number` | The replica count     |
+| Name        | Type     | Description              |
+| ----------- | -------- | ------------------------ |
+| `name`      | `string` | The backend name         |
+| `namespace` | `string` | The backend namespace    |
+| `port`      | `number` | The backend port         |
+| `image`     | `string` | The docker image name    |
+| `replicas`  | `number` | The replica count        |
+| `volumes`   | `object` | The volume configuration |

--- a/modules/backend/main.tf
+++ b/modules/backend/main.tf
@@ -41,6 +41,53 @@ resource "kubernetes_service" "main" {
   }
 }
 
+locals {
+  volumes = {
+    for key, volume in var.volumes : key => {
+      type      = volume.type
+      name      = try(volume.name, key)
+      path      = try(volume.path, format("/azure/%s", try(volume.name, key)))
+      directory = try(volume.directory, "")
+      read_only = try(volume.read_only, false)
+
+      config = volume.type != "config" ? null : {
+        name = volume.config.name
+        mode = try(volume.config.mode, "0644")
+
+        items = [
+          for item in try(volume.config.items, []) : {
+            name = item.name
+            path = item.path
+            mode = try(item.mode, null)
+          }
+        ]
+      }
+
+      secret = volume.type != "secret" ? null : {
+        name = volume.secret.name
+        mode = try(volume.secret.mode, "0644")
+
+        items = [
+          for item in try(volume.secret.items, []) : {
+            name = item.name
+            path = item.path
+            mode = try(item.mode, null)
+          }
+        ]
+      }
+
+      share = volume.type != "share" ? null : {
+        name = volume.share.name
+
+        account = {
+          name = volume.share.account.name
+          keys = volume.share.account.keys
+        }
+      }
+    }
+  }
+}
+
 resource "kubernetes_deployment" "main" {
   metadata {
     name      = var.name
@@ -70,6 +117,73 @@ resource "kubernetes_deployment" "main" {
             protocol       = "TCP"
             container_port = 80
           }
+
+          dynamic "volume_mount" {
+            for_each = local.volumes
+
+            content {
+              name       = volume_mount.value.name
+              mount_path = volume_mount.value.path
+              sub_path   = volume_mount.value.directory
+              read_only  = volume_mount.value.read_only
+            }
+          }
+        }
+
+        dynamic "volume" {
+          for_each = local.volumes
+
+          content {
+            name = volume.value.name
+
+            dynamic "config_map" {
+              for_each = volume.value.type == "config" ? [""] : []
+
+              content {
+                name         = volume.value.config.name
+                default_mode = volume.value.config.mode
+
+                dynamic "items" {
+                  for_each = volume.value.config.items
+
+                  content {
+                    key  = items.value.name
+                    mode = items.value.mode
+                    path = items.value.path
+                  }
+                }
+              }
+            }
+
+            dynamic "secret" {
+              for_each = volume.value.type == "secret" ? [""] : []
+
+              content {
+                secret_name  = volume.value.secret.name
+                default_mode = volume.value.secret.mode
+
+                dynamic "items" {
+                  for_each = volume.value.secret.items
+
+                  content {
+                    key  = items.value.name
+                    mode = items.value.mode
+                    path = items.value.path
+                  }
+                }
+              }
+            }
+
+            dynamic "azure_file" {
+              for_each = volume.value.type == "share" ? [""] : []
+
+              content {
+                secret_name = kubernetes_secret.volume[volume.key].metadata.0.name
+                share_name  = volume.value.share.name
+                read_only   = volume.value.read_only
+              }
+            }
+          }
         }
       }
     }
@@ -89,5 +203,23 @@ resource "kubernetes_pod_disruption_budget" "main" {
     selector {
       match_labels = local.labels
     }
+  }
+}
+
+resource "kubernetes_secret" "volume" {
+  for_each = {
+    for key, volume in local.volumes : key => volume
+    if volume.type == "share"
+  }
+
+  metadata {
+    name      = format("%s-%s-volume", var.name, each.key)
+    namespace = local.namespace
+    labels    = local.labels
+  }
+
+  data = {
+    azurestorageaccountname = each.value.share.account.name
+    azurestorageaccountkey  = each.value.share.account.keys.0
   }
 }

--- a/modules/backend/outputs.tf
+++ b/modules/backend/outputs.tf
@@ -22,3 +22,8 @@ output "replicas" {
   description = "The replica count"
   value       = var.replicas
 }
+
+output "volumes" {
+  description = "The volume configuration"
+  value       = var.volumes
+}

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -19,3 +19,9 @@ variable "replicas" {
   default     = 1
   type        = number
 }
+
+variable "volumes" {
+  description = "The volume configuration"
+  default     = {}
+  type        = any
+}


### PR DESCRIPTION
This adds support for mounting `config`, `secret` and `share` volume types to backend containers.