### PR TITLE
Update azurerm provider version

### DIFF
--- a/modules/ip-address/versions.tf
+++ b/modules/ip-address/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    azurerm = ">= 1.42, < 2.0"
+    azurerm = ">= 2.5"
   }
 }

--- a/tests/complete/providers.tf
+++ b/tests/complete/providers.tf
@@ -1,0 +1,3 @@
+provider "azurerm" {
+  features {}
+}

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12"
 
   required_providers {
-    azurerm    = ">= 1.42, < 2.0"
+    azurerm    = ">= 2.5"
     kubernetes = ">= 1.10"
   }
 }


### PR DESCRIPTION
This updates the `azurerm` provider version to keep up to date with the latest changes and bug fixes and maintain compatibility with the `terraform-azurerm-aks` module.