### PR TITLE
Simplify backend volumes

### DIFF
--- a/modules/backend/README.md
+++ b/modules/backend/README.md
@@ -15,54 +15,42 @@ module "backend" {
   image     = "nginx:latest"
   replicas  = 3
 
-  volumes = {
-    one = {
-      name = "one"
-      type = "config"
-      path = "/azure/config"
+  configs = {
+    config = {
+      name = "config"
+      path = "/config"
+      mode = "0644"
 
       config = {
-        name = "aks-backend-config"
-        mode = "0777"
-
-        items = [
-          {
-            name = "one.yml"
-            mode = "0644"
-            path = "path/to/one.yml"
-          },
-          {
-            name = "two.yml"
-            mode = "0700"
-            path = "path/to/two.yml"
-          }
-        ]
+        name = "aks-ingress-backend-config"
       }
     }
+  }
 
-    two = {
-      name = "two"
-      type = "secret"
-      path = "/azure/secret"
+  secrets = {
+    secret = {
+      name = "secret"
+      path = "/secret"
+      mode = "0644"
 
       secret = {
-        name = "aks-backend-secret"
-        mode = "0777"
+        name = "aks-ingress-backend-secret"
       }
     }
+  }
 
-    three = {
-      name      = "three"
-      type      = "share"
-      path      = "/azure/share"
-      directory = "production"
-      read_only = true
+  files = {
+    files = {
+      name   = "files"
+      source = "files"
+      target = "/files"
+      write  = false
 
       share = {
         name = "myshare"
 
         account = {
-          name = "myaccount"
+          name = "mystorageaccount"
           keys = ["key"]
         }
       }
@@ -73,49 +61,48 @@ module "backend" {
 
 ## Inputs
 
-| Name                             | Type     | Default    | Description                                         |
-| -------------------------------- | -------- | ---------- | --------------------------------------------------- |
-| `name`                           | `string` |            | The backend name                                    |
-| `namespace`                      | `string` | `null`     | The backend namespace or `null` to create a new one |
-| `image`                          | `string` |            | The docker image name                               |
-| `replicas`                       | `number` | `1`        | The replica count                                   |
-| `volumes`                        | `object` |            | The volume configuration                            |
-| `volumes.*`                      | `object` |            | The volume instance configuration                   |
-| `volumes.*.type`                 | `string` |            | The volume type (`config`, `secret` or `share`)     |
-| `volumes.*.name`                 | `string` | *computed* | The volume name (defaults to volume key)            |
-| `volumes.*.path`                 | `string` |            | The volume mount path                               |
-| `volumes.*.directory`            | `string` | `""`       | The volume source path                              |
-| `volumes.*.read_only`            | `bool`   | `false`    | Enable read-only access to volume                   |
-| `volumes.*.config`               | `object` | `null`     | The `config` volume type configuration              |
-| `volumes.*.config.name`          | `string` |            | The Kubernetes config name                          |
-| `volumes.*.config.mode`          | `string` | `0644`     | The Kubernetes config permissions mode default      |
-| `volumes.*.config.items`         | `list`   | *all*      | The Kubernetes config file list                     |
-| `volumes.*.config.items.*`       | `object` |            | The Kubernetes config file configuration            |
-| `volumes.*.config.items.*.name`  | `string` |            | The Kubernetes config file name                     |
-| `volumes.*.config.items.*.mode`  | `string` | `null`     | The Kubernetes config file permissions mode         |
-| `volumes.*.config.items.*.path`  | `string` |            | The Kubernetes config file mount path               |
-| `volumes.*.secret`               | `object` | `null`     | The `secret` volume type configuration              |
-| `volumes.*.secret.name`          | `string` |            | The Kubernetes secret name                          |
-| `volumes.*.secret.mode`          | `string` | `0644`     | The Kubernetes secret permissions mode default      |
-| `volumes.*.secret.items`         | `list`   | *all*      | The Kubernetes secret file list                     |
-| `volumes.*.secret.items.*`       | `object` |            | The Kubernetes secret file configuration            |
-| `volumes.*.secret.items.*.name`  | `string` |            | The Kubernetes secret file name                     |
-| `volumes.*.secret.items.*.mode`  | `string` | `null`     | The Kubernetes secret file permissions mode         |
-| `volumes.*.secret.items.*.path`  | `string` |            | The Kubernetes secret file mount path               |
-| `volumes.*.share`                | `object` | `null`     | The `share` volume type configuration               |
-| `volumes.*.share.name`           | `string` |            | The Azure file share name                           |
-| `volumes.*.share.account`        | `object` |            | The Azure storage account configuration             |
-| `volumes.*.share.account.name`   | `string` |            | The Azure storage account name                      |
-| `volumes.*.share.account.keys`   | `list`   |            | The Azure storage account access keys               |
-| `volumes.*.share.account.keys.*` | `string` |            | The Azure storage account access key                |
+| Name                           | Type     | Default    | Description                                         |
+| ------------------------------ | -------- | ---------- | --------------------------------------------------- |
+| `name`                         | `string` |            | The backend name                                    |
+| `namespace`                    | `string` | `null`     | The backend namespace or `null` to create a new one |
+| `image`                        | `string` |            | The docker image name                               |
+| `replicas`                     | `number` | `1`        | The replica count                                   |
+| `configs`                      | `object` | `{}`       | The config volume mount configuration               |
+| `configs.*`                    | `object` |            | A config volume mount configuration entry           |
+| `configs.*.name`               | `string` | *computed* | The config volume mount name                        |
+| `configs.*.path`               | `string` | *computed* | The config volume mount path                        |
+| `configs.*.mode`               | `string` | `"0644"`   | The config volume mount file permissions            |
+| `configs.*.config`             | `object` |            | The config resource configuration                   |
+| `configs.*.config.name`        | `string` |            | The config resource name                            |
+| `secrets`                      | `object` | `{}`       | The secret volume mount configuration               |
+| `secrets.*`                    | `object` |            | A secret volume mount configuration entry           |
+| `secrets.*.name`               | `string` | *computed* | The secret volume mount name                        |
+| `secrets.*.path`               | `string` | *computed* | The secret volume mount path                        |
+| `secrets.*.mode`               | `string` | `"0644"`   | The secret volume mount file permissions            |
+| `secrets.*.config`             | `object` |            | The secret resource configuration                   |
+| `secrets.*.config.name`        | `string` |            | The secret resource name                            |
+| `files`                        | `object` | `{}`       | The file share volume mount configuration           |
+| `files.*`                      | `object` |            | A file share volume mount configuration entry       |
+| `files.*.name`                 | `string` | *computed* | The file share volume mount name                    |
+| `files.*.source`               | `string` | `""`       | The source directory in the file share              |
+| `files.*.target`               | `string` | *computed* | The target path in the container                    |
+| `files.*.write`                | `bool`   | `true`     | Enable write access to files                        |
+| `files.*.share`                | `object` |            | The file share configuration                        |
+| `files.*.share.name`           | `string` |            | The file share name                                 |
+| `files.*.share.account`        | `object` |            | The file share storage account configuration        |
+| `files.*.share.account.name`   | `string` |            | The storage account name                            |
+| `files.*.share.account.keys`   | `list`   |            | The storage account access keys                     |
+| `files.*.share.account.keys.*` | `string` |            | A storage account access key                        |
 
 ## Outputs
 
-| Name        | Type     | Description              |
-| ----------- | -------- | ------------------------ |
-| `name`      | `string` | The backend name         |
-| `namespace` | `string` | The backend namespace    |
-| `port`      | `number` | The backend port         |
-| `image`     | `string` | The docker image name    |
-| `replicas`  | `number` | The replica count        |
-| `volumes`   | `object` | The volume configuration |
+| Name        | Type     | Description                               |
+| ----------- | -------- | ----------------------------------------- |
+| `name`      | `string` | The backend name                          |
+| `namespace` | `string` | The backend namespace                     |
+| `port`      | `number` | The backend port                          |
+| `image`     | `string` | The docker image name                     |
+| `replicas`  | `number` | The replica count                         |
+| `configs`   | `object` | The config volume mount configuration     |
+| `secrets`   | `object` | The secret volume mount configuration     |
+| `files`     | `object` | The file share volume mount configuration |

--- a/modules/backend/outputs.tf
+++ b/modules/backend/outputs.tf
@@ -23,7 +23,18 @@ output "replicas" {
   value       = var.replicas
 }
 
-output "volumes" {
-  description = "The volume configuration"
-  value       = var.volumes
+output "configs" {
+  description = "The config volume mount configuration"
+  value       = local.configs
+}
+
+output "secrets" {
+  description = "The secret volume mount configuration"
+  value       = local.secrets
+}
+
+output "files" {
+  description = "The file share volume mount configuration"
+  value       = local.files
+  sensitive   = true
 }

--- a/modules/backend/variables.tf
+++ b/modules/backend/variables.tf
@@ -20,8 +20,20 @@ variable "replicas" {
   type        = number
 }
 
-variable "volumes" {
-  description = "The volume configuration"
+variable "configs" {
+  description = "The config volume mount configuration"
+  default     = {}
+  type        = any
+}
+
+variable "secrets" {
+  description = "The secret volume mount configuration"
+  default     = {}
+  type        = any
+}
+
+variable "files" {
+  description = "The file share volume mount configuration"
   default     = {}
   type        = any
 }

--- a/modules/backend/versions.tf
+++ b/modules/backend/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.12.20"
 
   required_providers {
     kubernetes = ">= 1.10"

--- a/tests/complete/main.tf
+++ b/tests/complete/main.tf
@@ -21,54 +21,42 @@ module "backend" {
   image     = "nginx:latest"
   replicas  = 3
 
-  volumes = {
-    one = {
-      name = "one"
-      type = "config"
-      path = "/azure/config"
+  configs = {
+    config = {
+      name = "config"
+      path = "/config"
+      mode = "0644"
 
       config = {
         name = "aks-ingress-backend-config"
-        mode = "0777"
-
-        items = [
-          {
-            name = "one.yml"
-            mode = "0644"
-            path = "path/to/one.yml"
-          },
-          {
-            name = "two.yml"
-            mode = "0700"
-            path = "path/to/two.yml"
-          }
-        ]
       }
     }
+  }
 
-    two = {
-      name = "two"
-      type = "secret"
-      path = "/azure/secret"
+  secrets = {
+    secret = {
+      name = "secret"
+      path = "/secret"
+      mode = "0644"
 
       secret = {
         name = "aks-ingress-backend-secret"
-        mode = "0777"
       }
     }
+  }
 
-    three = {
-      name      = "three"
-      type      = "share"
-      path      = "/azure/share"
-      directory = "production"
-      read_only = true
+  files = {
+    files = {
+      name   = "files"
+      source = "files"
+      target = "/files"
+      write  = false
 
       share = {
         name = "myshare"
 
         account = {
-          name = "myaccount"
+          name = "mystorageaccount"
           keys = ["key"]
         }
       }


### PR DESCRIPTION
This simplifies backend volumes by separating them out to individual variables. It also removes the individual items for `config` and `secret` volumes but those can be reintroduced at a later date.