### PR TITLE
Add support for multiple route hosts

### DIFF
--- a/modules/route/README.md
+++ b/modules/route/README.md
@@ -44,20 +44,23 @@ module "route" {
 
 ## Inputs
 
-| Name                | Type     | Default | Description               |
-| ------------------- | -------- | ------- | ------------------------- |
-| `name`              | `string` |         | The route name            |
-| `path`              | `string` | `/`     | The route path            |
-| `host`              | `object` |         | The host configuration    |
-| `host.name`         | `string` |         | The host name             |
-| `backend`           | `object` |         | The backend configuration |
-| `backend.name`      | `string` |         | The backend name          |
-| `backend.namespace` | `string` |         | The backend namespace     |
-| `backend.port`      | `number` |         | The backend port          |
-| `ingress`           | `object` |         | The ingress configuration |
-| `ingress.class`     | `string` |         | The ingress class         |
-| `issuer`            | `object` | `null`  | The issuer configuration  |
-| `issuer.name`       | `string` |         | The issuer name           |
+| Name                | Type                | Default | Description               |
+| ------------------- | ------------------- | ------- | ------------------------- |
+| `name`              | `string`            |         | The route name            |
+| `path`              | `string`            | `/`     | The route path            |
+| `host`              | `string` / `object` | `null`  | The host configuration    |
+| `host.name`         | `string`            |         | The host name             |
+| `hosts`             | `list`              | `[]`    | The hosts configuration   |
+| `hosts.*`           | `string` / `object` |         | The host configuration    |
+| `hosts.*.name`      | `string`            |         | The host name             |
+| `backend`           | `object`            |         | The backend configuration |
+| `backend.name`      | `string`            |         | The backend name          |
+| `backend.namespace` | `string`            |         | The backend namespace     |
+| `backend.port`      | `number`            |         | The backend port          |
+| `ingress`           | `object`            |         | The ingress configuration |
+| `ingress.class`     | `string`            |         | The ingress class         |
+| `issuer`            | `object`            | `null`  | The issuer configuration  |
+| `issuer.name`       | `string`            |         | The issuer name           |
 
 ## Outputs
 
@@ -65,7 +68,8 @@ module "route" {
 | --------- | -------- | ------------------------- |
 | `name`    | `string` | The route name            |
 | `path`    | `string` | The route path            |
-| `host`    | `object` | The host configuration    |
+| `hosts`   | `list`   | The hosts configuration   |
+| `hosts.*` | `string` | The host name             |
 | `backend` | `object` | The backend configuration |
 | `ingress` | `object` | The ingress configuration |
 | `issuer`  | `object` | The issuer configuration  |

--- a/modules/route/main.tf
+++ b/modules/route/main.tf
@@ -9,7 +9,8 @@ locals {
 }
 
 locals {
-  hosts = [for host in (var.host == null ? var.hosts : concat([var.host], var.hosts)) : can(host.name) ? host.name : host]
+  host  = try(var.host.name, var.host)
+  hosts = concat(local.host == null ? [] : [local.host], [for host in var.hosts : try(host.name, host)])
 }
 
 resource "kubernetes_ingress" "main" {

--- a/modules/route/outputs.tf
+++ b/modules/route/outputs.tf
@@ -8,9 +8,9 @@ output "path" {
   value       = var.path
 }
 
-output "host" {
-  description = "The host configuration"
-  value       = var.host
+output "hosts" {
+  description = "The hosts configuration"
+  value       = local.hosts
 }
 
 output "backend" {

--- a/modules/route/variables.tf
+++ b/modules/route/variables.tf
@@ -11,9 +11,14 @@ variable "path" {
 
 variable "host" {
   description = "The host configuration"
-  type = object({
-    name = string
-  })
+  default     = null
+  type        = any
+}
+
+variable "hosts" {
+  description = "The hosts configuration"
+  default     = []
+  type        = list(any)
 }
 
 variable "backend" {


### PR DESCRIPTION
This adds support for providing multiple hosts to a route. This is done in a backwards-compatible way by combining both `host` and `hosts` if provided. This also adds the ability to use the `host` module from `terraform-azurerm-dns` as an input by accepting both objects with a `name` and strings.